### PR TITLE
Add opt-in visual style presets and per-feature building/road visual overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,39 @@ function Update(){
 
 
 
+
+### Building & Road Visual Options (Style Package)
+
+GeoLayer now supports opt-in style presets and per-feature overrides without changing default visuals.
+
+```javascript
+const buildings = new CUBE.GeoLayer('buildings', buildingGeojson).Buildings({
+  style: 'nightNeon',            // built-in style package preset
+  buildingVisual: {
+    enable: true,                // must be enabled explicitly
+    windowGlow: 0.22             // override preset values
+  }
+})
+
+const roads = new CUBE.GeoLayer('roads', roadGeojson).Road({
+  style: 'nightNeon',
+  width: 16,
+  roadVisual: {
+    enable: true,
+    palette: { secondary: 0x33b1ff, tertiary: 0x2378c3 }
+  }
+})
+```
+
+Built-in style presets:
+- `cubeDefault`
+- `nightNeon`
+- `softDaylight`
+
+If both `style` and `buildingVisual` / `roadVisual` are provided, explicit visual options override the preset.
+
+See runnable example: `playground/visual-style.html`.
+
 ## Use with Threejs
 
 The CUBE.gl is build upon three.js. You can access the built-in three.js by CUBE.Space.three or CUBE.Space.Three(). The current CUBE build is using three.js 0.119. You can also try to implement a different version.

--- a/playground/visual-style.html
+++ b/playground/visual-style.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+  <title>CUBE.gl visual style options</title>
+  <script type="module" src="../src/index.js"></script>
+</head>
+
+<body>
+  <div id="cont" style="position: absolute; width: 100%; height: 100%;"></div>
+
+  <script>
+    Init()
+    Update()
+
+    const container = document.getElementById('cont')
+    let C
+
+    async function Init () {
+      C = new CUBE.Space(container, {
+        center: { latitude: 22.280278, longitude: 114.159444 },
+        scale: 10,
+        interaction: { enable: false },
+        camera: { position: { x: 4, y: 6, z: 4 } }
+      })
+
+      const [buildingRes, roadRes] = await Promise.all([
+        fetch('/assets/geo/project/building.geojson'),
+        fetch('/assets/geo/project/highway.geojson')
+      ])
+
+      const buildingsJson = await buildingRes.json()
+      const roadsJson = await roadRes.json()
+
+      const buildings = new CUBE.GeoLayer('buildings', buildingsJson).Buildings({
+        merge: false,
+        style: 'nightNeon',
+        buildingVisual: {
+          enable: true,
+          windowGlow: 0.22
+        }
+      })
+
+      const roads = new CUBE.GeoLayer('roads', roadsJson).Road({
+        width: 16,
+        style: 'nightNeon',
+        roadVisual: {
+          enable: true,
+          palette: {
+            secondary: 0x33b1ff,
+            tertiary: 0x2378c3
+          }
+        }
+      })
+
+      roads.position.y -= 0.1
+      C.Add(buildings)
+      C.Add(roads)
+    }
+
+    function Update () {
+      requestAnimationFrame(Update)
+      C.Runtime()
+    }
+  </script>
+</body>
+
+</html>

--- a/src/layers/Geo.js
+++ b/src/layers/Geo.js
@@ -19,6 +19,29 @@ import { Animation } from '../animation/Animation'
 import { Layer } from './Layer'
 import { CurvePath, LineCurve } from 'three'
 
+const VISUAL_STYLE_PACKS = {
+  cubeDefault: {
+    buildingVisual: { mode: 'advanced', minLevels: 4, windowColor: 0xb8dcff, windowGlow: 0.1, roughness: 0.62, metalness: 0.12 },
+    roadVisual: { mode: 'advanced', widthScale: 1, opacity: 0.96, highlightPrimary: true, highlightColor: 0x65d8ff }
+  },
+  nightNeon: {
+    buildingVisual: { mode: 'advanced', minLevels: 3, windowColor: 0x8ce8ff, windowGlow: 0.18, roughness: 0.5, metalness: 0.22 },
+    roadVisual: { mode: 'advanced', widthScale: 1.05, opacity: 0.9, highlightPrimary: true, highlightColor: 0x00e6ff, palette: { motorway: 0x00e6ff, trunk: 0x00b3ff, primary: 0x6ecbff } }
+  },
+  softDaylight: {
+    buildingVisual: { mode: 'basic', minLevels: 5, windowColor: 0xf6fbff, windowGlow: 0.05, roughness: 0.72, metalness: 0.08 },
+    roadVisual: { mode: 'basic', widthVariance: 0.5, colorJitter: true }
+  }
+}
+
+function resolveVisualOptions (options = {}, key) {
+  const styleName = options.style
+  const fromPack = styleName && VISUAL_STYLE_PACKS[styleName] && VISUAL_STYLE_PACKS[styleName][key]
+  const direct = options[key] || {}
+  if (!fromPack) return direct
+  return { ...fromPack, ...direct }
+}
+
 export class GeoLayer {
   /**
      * @param {String} name name of the layer
@@ -181,6 +204,7 @@ export class GeoLayer {
             if (options.collider) this.layer_colliders.Add(building.helper) // Invisiable collider
           } else {
             const mesh = new THREE.Mesh(building.geometry, this.mat_building)
+            addBuildingWindows(mesh, info, options)
             const n = verify(info, 'name')
             mesh.name = n || 'building'
             mesh.info = info
@@ -252,7 +276,7 @@ export class GeoLayer {
           const road = addRoad3(fel.geometry.coordinates, terrain)
           if (road) {
             // allPoints = allPoints.concat(road)
-            allPoints.push(road);
+            allPoints.push({ points: road, info: info });
           }
         }
       }
@@ -264,7 +288,8 @@ export class GeoLayer {
     // 2021.06.16 Major Updates: Use Line Geometry to support fat line for realistic highway generation
     
     for(let ip=0;ip<allPoints.length;ip++) {
-      const ipp = allPoints[ip]
+      const ipp = allPoints[ip].points
+      const roadInfo = allPoints[ip].info || {}
 
       const geometry = new LineGeometry()
     
@@ -283,11 +308,13 @@ export class GeoLayer {
       geometry.setPositions( positions )
       geometry.rotateZ(Math.PI)
 
-      const widthScale = window.CUBE_GLOBAL.MAP_SCALE * (options.width || 12)
+      const roadStyle = createRoadVisualStyle(options, roadInfo, ipp.length)
 
       const matLine = new LineMaterial( {
-        color: options.color || 0x4287f5,
-        linewidth: widthScale * .0001, // in world units
+        color: roadStyle.color,
+        opacity: roadStyle.opacity,
+        transparent: roadStyle.opacity < 1,
+        linewidth: roadStyle.widthScale * .0001, // in world units
         vertexColors: false,
         dashed: false,
         alphaToCoverage: true,
@@ -323,7 +350,6 @@ export class GeoLayer {
     // Terrain
     const terrain = options.terrain ? options.terrain.children[0].geometry : false
 
-    const widthScale = window.CUBE_GLOBAL.MAP_SCALE * (options.width || 12)
 
     // Animation constraints
     const ANI_MIN_LENGTH = 5       // minimum road length to animate
@@ -371,9 +397,12 @@ export class GeoLayer {
       lineGeo.setPositions(positions)
       lineGeo.rotateZ(Math.PI)
 
+      const roadStyle = createRoadVisualStyle(options, info, ipp.length)
       const matLine = mat || new LineMaterial({
-        color: options.color || 0x1B4686,
-        linewidth: widthScale * 0.0001,
+        color: roadStyle.color || 0x1B4686,
+        opacity: roadStyle.opacity,
+        transparent: roadStyle.opacity < 1,
+        linewidth: roadStyle.widthScale * 0.0001,
         worldUnits: true
       })
       if (matLine.resolution) matLine.resolution.set(window.innerWidth, window.innerHeight)
@@ -404,7 +433,7 @@ export class GeoLayer {
 
           const aniMat = new LineMaterial({
             color: options.animationColor || 0x00FFFF,
-            linewidth: widthScale * 0.00012,
+            linewidth: roadStyle.widthScale * 0.00012,
             worldUnits: true,
             transparent: true,
             depthWrite: false
@@ -536,6 +565,58 @@ export class GeoLayer {
 
     return this.layer.Layer()
   }
+}
+
+
+function createRoadVisualStyle (options = {}, info = {}, pointCount = 0) {
+  const style = resolveVisualOptions(options, 'roadVisual')
+  const levelMap = { motorway: 1.2, trunk: 1.1, primary: 1.0, secondary: 0.92, tertiary: 0.88, residential: 0.8, service: 0.72 }
+  const baseWidth = options.width || 12
+  const highway = verify(info, 'highway')
+
+  let widthFactor = 1
+  let color = options.color || 0x4287f5
+  let opacity = 1
+
+  if (style.enable) {
+    if (style.mode === 'advanced') {
+      const mapped = levelMap[highway] || 0.78
+      widthFactor = mapped * (style.widthScale || 1)
+      opacity = style.opacity || 0.96
+      if (style.palette && style.palette[highway]) color = style.palette[highway]
+      else if (style.highlightPrimary && (highway === 'motorway' || highway === 'primary')) color = style.highlightColor || 0x64c8ff
+    } else if (style.mode === 'basic') {
+      const variance = ((pointCount % 7) - 3) * 0.03
+      widthFactor = 1 + variance * (style.widthVariance || 0.8)
+      if (style.colorJitter) {
+        const c = new THREE.Color(color)
+        c.offsetHSL(0, 0, variance * 0.35)
+        color = c.getHex()
+      }
+    }
+  }
+
+  return { widthScale: window.CUBE_GLOBAL.MAP_SCALE * baseWidth * widthFactor, color, opacity }
+}
+
+function addBuildingWindows (mesh, info = {}, options = {}) {
+  const visual = resolveVisualOptions(options, 'buildingVisual')
+  if (!visual.enable || visual.mode !== 'advanced') return
+
+  const levels = parseFloat(info['building:levels'] || (info.tags && info.tags['building:levels']) || 1)
+  if (!Number.isFinite(levels) || levels < (visual.minLevels || 3)) return
+
+  const windowColor = visual.windowColor || 0xb8dcff
+  const emissiveIntensity = visual.windowGlow || 0.12
+  const wallColor = options.color ? options.color : 0x7884B2
+
+  mesh.material = new THREE.MeshStandardMaterial({
+    color: wallColor,
+    roughness: visual.roughness || 0.65,
+    metalness: visual.metalness || 0.15,
+    emissive: windowColor,
+    emissiveIntensity
+  })
 }
 
 function addBuilding (coordinates, collider = false, info = {}, height = 1, terrain) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -221,6 +221,25 @@ export class Layer {
   Find(name: string): THREE.Object3D | undefined
 }
 
+export type GeoVisualStylePreset = 'cubeDefault' | 'nightNeon' | 'softDaylight'
+
+export interface BuildingVisualOptions {
+  /** Enable visual enhancement (default keeps current style) */
+  enable?: boolean
+  /** basic: lightweight style variation, advanced: window/glow based facade */
+  mode?: 'basic' | 'advanced'
+  /** Advanced mode: minimum floors before applying window facade */
+  minLevels?: number
+  /** Advanced mode: emissive window color */
+  windowColor?: number
+  /** Advanced mode: emissive intensity */
+  windowGlow?: number
+  /** Advanced mode: material roughness */
+  roughness?: number
+  /** Advanced mode: material metalness */
+  metalness?: number
+}
+
 export interface BuildingOptions {
   /** Merge geometries for better performance (default: false) */
   merge?: boolean
@@ -230,6 +249,31 @@ export interface BuildingOptions {
   collider?: boolean
   /** Terrain object for altitude fitting */
   terrain?: THREE.Group
+  /** Optional style package preset name */
+  style?: GeoVisualStylePreset
+  /** Optional building visual enhancement options (overrides style preset) */
+  buildingVisual?: BuildingVisualOptions
+}
+
+export interface RoadVisualOptions {
+  /** Enable visual enhancement (default keeps current style) */
+  enable?: boolean
+  /** basic: lightweight style variation, advanced: hierarchy-aware styling */
+  mode?: 'basic' | 'advanced'
+  /** Advanced mode: width multiplier */
+  widthScale?: number
+  /** Advanced mode: emphasize primary and motorway */
+  highlightPrimary?: boolean
+  /** Advanced mode: highlight color */
+  highlightColor?: number
+  /** Advanced mode: road class color palette */
+  palette?: Record<string, number>
+  /** Basic mode: lightness jitter */
+  colorJitter?: boolean
+  /** Basic mode: random-ish width variation amount */
+  widthVariance?: number
+  /** Advanced mode: opacity */
+  opacity?: number
 }
 
 export interface RoadOptions {
@@ -239,6 +283,10 @@ export interface RoadOptions {
   width?: number
   /** Terrain object for altitude fitting */
   terrain?: THREE.Group
+  /** Optional style package preset name */
+  style?: GeoVisualStylePreset
+  /** Optional road visual enhancement options (overrides style preset) */
+  roadVisual?: RoadVisualOptions
 }
 
 export interface RoadSpOptions extends RoadOptions {


### PR DESCRIPTION
### Motivation
- Provide opt-in visual styling for GeoLayer so users can apply cohesive presets without changing defaults.
- Allow per-layer and per-feature overrides for building facades (window glow) and road appearance (width, color, opacity).
- Expose style presets and typed options to improve ergonomics and enable richer visuals for examples and demos.

### Description
- Introduces built-in style packs in `src/layers/Geo.js` (`cubeDefault`, `nightNeon`, `softDaylight`) and a `resolveVisualOptions` helper to merge presets with explicit per-call overrides.
- Adds `createRoadVisualStyle` to compute per-road visual parameters (width, color, opacity) using layer options and feature properties, and updates `Road`/`RoadSp` to use the computed style and to carry `info` alongside point arrays.
- Adds `addBuildingWindows` to apply an emissive-window facade material for advanced building visuals when enabled and updates building mesh creation to call it.
- Extends TypeScript definitions in `types/index.d.ts` with `GeoVisualStylePreset`, `BuildingVisualOptions`, `RoadVisualOptions`, and new `style`, `buildingVisual`, and `roadVisual` options on `BuildingOptions` and `RoadOptions`.
- Adds a runnable demo `playground/visual-style.html` and documents the new feature in `README.md` with example usage and the list of built-in presets.

### Testing
- Ran TypeScript typecheck with `tsc` against the updated `types` and it completed successfully.
- Performed a project build with `npm run build` and the bundle compiled without errors.
- No automated unit tests were present for the new visuals, so visual verification was exercised via the added `playground/visual-style.html` example (manual visual check).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc385aab50832b8e9cae611f9091eb)